### PR TITLE
fix: TypeScript v6 の非推奨オプションを修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "rootDir": "./src",
     "outDir": "./dist",
@@ -24,11 +24,9 @@
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
     "types": ["node"],
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6 で非推奨となったオプションを修正します。

Fixes #2424

## 変更内容

### tsconfig.json

- `moduleResolution` を `"Node"` から `"bundler"` に変更
  - TypeScript v7 では `ignoreDeprecations` が機能しなくなるため、非推奨オプションを削除
- `ignoreDeprecations: "6.0"` を削除
- `baseUrl: "."` を削除
- `paths` の値を `"src/*"` から `"./src/*"` に変更（tsconfig.json からの相対パスに統一）

## 確認事項

- [x] `tsc --noEmit` でビルドエラーがないことを確認
- [x] `pnpm lint` で Lint エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)