### PR TITLE
fix: book000 reusable workflowのdigest指定をmasterに変更し、allow-unsafe-pr-checkoutを設定する

### DIFF
--- a/.github/workflows/add-reviewer.yml
+++ b/.github/workflows/add-reviewer.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   add-reviewer:
     name: Add reviewer
-    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,13 +78,14 @@ jobs:
     name: Docker CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [
           { imageName: "book000/niconico-mylist-video-checker", context: ".", file: "Dockerfile", packageName: "niconico-mylist-video-checker" }
         ]
       registry: registry.hub.docker.com
+      allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/hadolint-ci.yml
+++ b/.github/workflows/hadolint-ci.yml
@@ -13,4 +13,4 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@master

--- a/.github/workflows/nodejs-ci-pnpm.yml
+++ b/.github/workflows/nodejs-ci-pnpm.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   node-ci:
     name: Node CI
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@master


### PR DESCRIPTION
## 概要

book000/book000#124 のロールアウト対応として、本リポジトリの `.github/workflows/*.yml` から呼び出している book000/templates の reusable workflow について以下を実施しました。

## 変更内容

- `uses: book000/templates/.github/workflows/reusable-*.yml@<digest>` を `@master` に変更
- `reusable-docker.yml` を呼び出している箇所に `allow-unsafe-pr-checkout` を追加
  - book000/templates#430 で追加された入力。既存の approval-gate（Environment `fork-pr-build`）承認済みのフォーク PR に限りチェックアウトを許可する
  - 条件式は book000/mitm-packet-sniffer#257 の実装パターンに準拠

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` で全対象ファイルの YAML 構文を確認

## 関連

- book000/book000#124 (このリポジトリ横断対応の親 Issue)
- book000/templates#430 (allow-unsafe-pr-checkout 追加元)
- book000/mitm-packet-sniffer#257 (実装パターンの参照元)
- book000/kindle-booklog#2350 (パイロット実施例)