### PR TITLE
fix: eslint-config 1.16.3 (unicorn ルール) 対応の lint エラーを修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,13 +72,13 @@ async function main() {
     return
   }
 
-  const discord = new Discord(config.get('discord'))
-
   if (!fs.existsSync(watchMyListsPath)) {
     logger.error(`❌ watchMyListsPath (${watchMyListsPath}) file not found`)
     process.exitCode = 1
     return
   }
+
+  const discord = new Discord(config.get('discord'))
 
   const watchMyLists = JSON.parse(fs.readFileSync(watchMyListsPath, 'utf8'))
   let notified: Record<number, string[] | undefined> = {}
@@ -90,7 +90,9 @@ async function main() {
   for (const listId of watchMyLists) {
     const mylist = await getMylist(listId)
     const newItems = mylist.items.filter((item: NicoNicoMyListItem) =>
-      notified[mylist.id] ? !notified[mylist.id]?.includes(item.watchId) : true
+      Object.hasOwn(notified, mylist.id)
+        ? !notified[mylist.id]?.includes(item.watchId)
+        : true
     )
     if (newItems.length > 0) {
       logger.info(


### PR DESCRIPTION
## 概要

Renovate PR #2450 (`@book000/eslint-config` 1.15.4 -> 1.16.3) が新しい `eslint-plugin-unicorn` のルールを取り込んだ結果、既存コードで以下の 2 件の lint エラーが発生していました。

- `unicorn/no-declarations-before-early-exit`: `src/main.ts` の `discord` 変数宣言が早期リターンより前にあった
- `unicorn/no-computed-property-existence-check`: `notified[mylist.id]` の動的プロパティ存在チェックが古い書き方だった

## 対応内容

- `discord` 変数の宣言を `watchMyListsPath` の早期リターン後に移動
- `notified[mylist.id]` の truthy チェックを `Object.hasOwn(notified, mylist.id)` に置き換え

## 動作確認

- `@book000/eslint-config@1.16.3` を一時的にインストールし、`pnpm run lint`（prettier + eslint + tsc）がクリーンになることを確認
- 上記の依存バンプは本 PR ではなく Renovate PR #2450 側の変更のため、確認後に revert し、既存の `1.15.4` でも `pnpm run lint` がクリーンなまま（デグレなし）であることを確認済み

挙動を変更しない、機械的な lint 修正です。