### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/
+watch-my-lists.json
+mylist.json


### PR DESCRIPTION
## 概要

`.worktreeinclude` を新規追加し、git worktree 作成時にローカル設定・状態ファイルを引き継げるようにする。

## 追加したパターン

```
data/
watch-my-lists.json
mylist.json
```

## 根拠 (Evidence)

- `.gitignore` で `data/` が除外されている（ローカルの実行時設定ディレクトリ）
- README.md: `data` ディレクトリに `config.json` を作成する手順が記載されている（Discord トークン・チャンネル ID を含む）
- `compose.yml`: ボリュームマウントで `./data/` を `/data/` にバインドしている
- `src/main.ts`: `NMVCConfiguration('./data/config.json')` で `data/` 配下から設定を読み込んでいる
- `src/main.ts`: `watchMyListsPath` のデフォルトは `watch-my-lists.json`（`WATCH_MY_LISTS_PATH` 環境変数で上書き可）で、`fs.readFileSync` + `JSON.parse` により読み込まれる
- `src/main.ts`: `mylistPath` のデフォルトは `mylist.json`（`MY_LIST_PATH` 環境変数で上書き可）で、存在する場合に通知済み状態として読み込まれる

## レビュー状況

- lite-review 実施済み: 指摘事項なし

## 関連 Issue

https://github.com/book000/book000/issues/132
